### PR TITLE
Merge functionality from zig-ar

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -116,6 +116,14 @@ pub fn main() anyerror!void {
     const archive_path = args[arg_index];
 
     switch (operation) {
+        .insert => {
+            const file = try fs.cwd().createFile(archive_path, .{});
+            defer file.close();
+            
+            var archive = Archive.create(file, archive_path);
+            try archive.addFiles(allocator, args[arg_index+1..]);
+            try archive.finalize();
+        },
         .display_contents => {
             const file = try fs.cwd().openFile(archive_path, .{});
             defer file.close();

--- a/src/main.zig
+++ b/src/main.zig
@@ -119,10 +119,20 @@ pub fn main() anyerror!void {
         .insert => {
             const file = try fs.cwd().createFile(archive_path, .{});
             defer file.close();
-            
+
             var archive = Archive.create(file, archive_path);
-            try archive.addFiles(allocator, args[arg_index+1..]);
+            try archive.addFiles(allocator, args[arg_index + 1 ..]);
             try archive.finalize();
+        },
+        .delete => {
+            const file = try fs.cwd().openFile(archive_path, .{ .write = true });
+            defer file.close();
+
+            var archive = Archive.create(file, archive_path);
+            if (archive.parse(allocator, stderr)) {
+                try archive.deleteFiles(args[arg_index + 1 ..]);
+                try archive.finalize();
+            } else |err| return err;
         },
         .display_contents => {
             const file = try fs.cwd().openFile(archive_path, .{});


### PR DESCRIPTION
This PR adds ability to write, extract, print and delete (r, x, p, d)

The contents field is heap allocated for now, it is to be optimized later.
The finalize() function expects the file has been opened in write mode.
All the added functions has been designed to be worked with multiple file inputs.

The write function would break if a file name larger than 15 bytes is entered. Is it a todo to add string table, which would be done in a separate PR.

Symbol table writing is not present either.

The generates .a files are usable for actual linking by compilers if ran with ranlib, so its technically working...