### PR TITLE
Add symbol table writing support

### DIFF
--- a/src/archive/Archive.zig
+++ b/src/archive/Archive.zig
@@ -227,7 +227,7 @@ pub fn finalize(self: *Archive, allocator: *Allocator) !void {
             {
                 if (symbol_table.items.len != 0) {
                     if (symbol_table.items.len % 2 != 0)
-                        try symbol_table.append('\n');
+                        try symbol_table.append(0);
 
                     try writer.print("/{s}{: <10}`\n", .{ " " ** 47, symbol_table.items.len + (symbol_offset.items.len * 4) + 4 });
                     try writer.writeIntBig(u32, symbol_count);

--- a/src/archive/Archive.zig
+++ b/src/archive/Archive.zig
@@ -79,6 +79,8 @@ pub const Header = extern struct {
     ar_mode: [8]u8,
     ar_size: [10]u8,
     ar_fmag: [2]u8,
+
+    pub const format_string = "{s: <16}{: <12}{: <6}{: <6}{o: <8}{: <10}`\n";
 };
 
 pub const Modifiers = extern struct {
@@ -229,7 +231,11 @@ pub fn finalize(self: *Archive, allocator: *Allocator) !void {
                     if (symbol_table.items.len % 2 != 0)
                         try symbol_table.append(0);
 
-                    try writer.print("/{s}{: <10}`\n", .{ " " ** 47, symbol_table.items.len + (symbol_offset.items.len * 4) + 4 });
+                    try writer.print(
+                        Header.format_string,
+                        .{ "/", 0, 0, 0, 0, symbol_table.items.len + (symbol_offset.items.len * 4) + 4 },
+                    );
+
                     try writer.writeIntBig(u32, symbol_count);
 
                     for (symbol_offset.items) |off| {
@@ -271,7 +277,7 @@ pub fn finalize(self: *Archive, allocator: *Allocator) !void {
         var headerBuffer: [@sizeOf(Header)]u8 = undefined;
         _ = try std.fmt.bufPrint(
             &headerBuffer,
-            "{s: <16}{: <12}{: <6}{: <6}{o: <8}{: <10}`\n",
+            Header.format_string,
             .{ &header_names[index], file.contents.timestamp, file.contents.uid, file.contents.gid, file.contents.mode, file.contents.length },
         );
 

--- a/src/archive/Archive.zig
+++ b/src/archive/Archive.zig
@@ -322,6 +322,8 @@ pub fn finalize(self: *Archive, allocator: *Allocator) !void {
         else => unreachable,
     }
 
+    const is_bsd = (self.output_archive_type == .bsd) or (self.output_archive_type == .darwin64);
+
     // Write the files
     for (self.files.items) |file, index| {
         // Write the header
@@ -330,7 +332,7 @@ pub fn finalize(self: *Archive, allocator: *Allocator) !void {
         _ = try std.fmt.bufPrint(
             &headerBuffer,
             Header.format_string,
-            .{ &header_names[index], file.contents.timestamp, file.contents.uid, file.contents.gid, file.contents.mode, file.contents.length },
+            .{ &header_names[index], file.contents.timestamp, file.contents.uid, file.contents.gid, file.contents.mode, file.contents.length + if (is_bsd) file.name.len else 0 },
         );
 
         // TODO: handle errors

--- a/src/archive/Archive.zig
+++ b/src/archive/Archive.zig
@@ -494,7 +494,9 @@ pub fn insertFiles(self: *Archive, allocator: *Allocator, file_names: [][]const 
                     for (elf_file.symtab.items) |sym| {
                         switch (sym.st_info >> 4) {
                             elf.STB_WEAK, elf.STB_GLOBAL => {
-                                try archived_file.addSymbol(allocator, try allocator.dupe(u8, elf_file.getString(sym.st_name)));
+                                if (!(elf.SHN_LORESERVE <= sym.st_shndx and sym.st_shndx < elf.SHN_HIRESERVE and sym.st_shndx == elf.SHN_UNDEF)) {
+                                    try archived_file.addSymbol(allocator, try allocator.dupe(u8, elf_file.getString(sym.st_name)));
+                                }
                             },
                             else => {},
                         }

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -1,0 +1,196 @@
+const Object = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const elf = std.elf;
+const fs = std.fs;
+const log = std.log.scoped(.elf);
+const math = std.math;
+const mem = std.mem;
+
+const Allocator = mem.Allocator;
+
+file: fs.File,
+name: []const u8,
+file_offset: ?u32 = null,
+
+header: ?elf.Elf64_Ehdr = null,
+
+shdrs: std.ArrayListUnmanaged(elf.Elf64_Shdr) = .{},
+
+sections: std.ArrayListUnmanaged(u16) = .{},
+relocs: std.AutoHashMapUnmanaged(u16, u16) = .{},
+
+symtab: std.ArrayListUnmanaged(elf.Elf64_Sym) = .{},
+strtab: std.ArrayListUnmanaged(u8) = .{},
+
+symtab_index: ?u16 = null,
+
+pub fn deinit(self: *Object, allocator: *Allocator) void {
+    self.shdrs.deinit(allocator);
+    self.sections.deinit(allocator);
+    self.relocs.deinit(allocator);
+    self.symtab.deinit(allocator);
+    self.strtab.deinit(allocator);
+    allocator.free(self.name);
+}
+
+pub fn parse(self: *Object, allocator: *Allocator, target: std.Target) !void {
+    const reader = self.file.reader();
+    if (self.file_offset) |offset| {
+        try reader.context.seekTo(offset);
+    }
+    const header = try reader.readStruct(elf.Elf64_Ehdr);
+
+    if (!mem.eql(u8, header.e_ident[0..4], "\x7fELF")) {
+        log.debug("Invalid ELF magic {s}, expected \x7fELF", .{header.e_ident[0..4]});
+        return error.NotObject;
+    }
+    if (header.e_ident[elf.EI_VERSION] != 1) {
+        log.debug("Unknown ELF version {d}, expected 1", .{header.e_ident[elf.EI_VERSION]});
+        return error.NotObject;
+    }
+    if (header.e_ident[elf.EI_DATA] != elf.ELFDATA2LSB) {
+        log.err("TODO big endian support", .{});
+        return error.TODOBigEndianSupport;
+    }
+    if (header.e_ident[elf.EI_CLASS] != elf.ELFCLASS64) {
+        log.err("TODO 32bit support", .{});
+        return error.TODOElf32bitSupport;
+    }
+    if (header.e_type != elf.ET.REL) {
+        log.debug("Invalid file type {any}, expected ET.REL", .{header.e_type});
+        return error.NotObject;
+    }
+    if (header.e_machine != target.cpu.arch.toElfMachine()) {
+        log.debug("Invalid architecture {any}, expected {any}", .{
+            header.e_machine,
+            target.cpu.arch.toElfMachine(),
+        });
+        return error.InvalidCpuArch;
+    }
+    if (header.e_version != 1) {
+        log.debug("Invalid ELF version {d}, expected 1", .{header.e_version});
+        return error.NotObject;
+    }
+
+    assert(header.e_entry == 0);
+    assert(header.e_phoff == 0);
+    assert(header.e_phnum == 0);
+
+    self.header = header;
+
+    try self.parseShdrs(allocator, reader);
+    try self.parseSymtab(allocator);
+}
+
+fn parseShdrs(self: *Object, allocator: *Allocator, reader: anytype) !void {
+    const shnum = self.header.?.e_shnum;
+    if (shnum == 0) return;
+
+    const offset = self.file_offset orelse 0;
+    try reader.context.seekTo(offset + self.header.?.e_shoff);
+    try self.shdrs.ensureTotalCapacity(allocator, shnum);
+
+    var i: u16 = 0;
+    while (i < shnum) : (i += 1) {
+        const shdr = try reader.readStruct(elf.Elf64_Shdr);
+        self.shdrs.appendAssumeCapacity(shdr);
+
+        switch (shdr.sh_type) {
+            elf.SHT_SYMTAB => {
+                self.symtab_index = i;
+            },
+            elf.SHT_PROGBITS, elf.SHT_NOBITS => {
+                try self.sections.append(allocator, i);
+            },
+            elf.SHT_REL, elf.SHT_RELA => {
+                try self.relocs.putNoClobber(allocator, @intCast(u16, shdr.sh_info), i);
+            },
+            else => {},
+        }
+    }
+
+    // Parse shstrtab
+    var buffer = try self.readShdrContents(allocator, self.header.?.e_shstrndx);
+    defer allocator.free(buffer);
+    try self.strtab.appendSlice(allocator, buffer);
+}
+
+fn parseSymtab(self: *Object, allocator: *Allocator) !void {
+    if (self.symtab_index == null) return;
+
+    const symtab_shdr = self.shdrs.items[self.symtab_index.?];
+
+    // We first read the contents of string table associated with this symbol table
+    // noting the offset at which it is appended to the existing string table, which
+    // we will then use to fixup st_name offset within each symbol.
+    const strtab_offset = @intCast(u32, self.strtab.items.len);
+    var str_buffer = try self.readShdrContents(allocator, @intCast(u16, symtab_shdr.sh_link));
+    defer allocator.free(str_buffer);
+    try self.strtab.appendSlice(allocator, str_buffer);
+
+    var sym_buffer = try self.readShdrContents(allocator, self.symtab_index.?);
+    defer allocator.free(sym_buffer);
+    const syms = @alignCast(@alignOf(elf.Elf64_Sym), mem.bytesAsSlice(elf.Elf64_Sym, sym_buffer));
+    try self.symtab.ensureTotalCapacity(allocator, syms.len);
+
+    for (syms) |sym| {
+        var out_sym = sym;
+        if (sym.st_name > 0) {
+            out_sym.st_name += strtab_offset;
+        } else if (sym.st_info & 0xf == elf.STT_SECTION) {
+            // If the symbol is pointing to a section header, copy the sh_name offset as the new
+            // st_name offset.
+            const shdr = self.shdrs.items[sym.st_shndx];
+            out_sym.st_name = shdr.sh_name;
+        }
+        self.symtab.appendAssumeCapacity(out_sym);
+    }
+}
+
+fn sortBySeniority(aliases: []u32, object: *Object) void {
+    const Context = struct {
+        object: *Object,
+    };
+    const SortFn = struct {
+        fn lessThan(ctx: Context, lhs: u32, rhs: u32) bool {
+            const lhs_sym = ctx.object.symtab.items[lhs];
+            const lhs_sym_bind = lhs_sym.st_info >> 4;
+            const rhs_sym = ctx.object.symtab.items[rhs];
+            const rhs_sym_bind = rhs_sym.st_info >> 4;
+
+            if (lhs_sym_bind == rhs_sym_bind) {
+                return false;
+            }
+            if (lhs_sym_bind == elf.STB_GLOBAL) {
+                return true;
+            } else if (lhs_sym_bind == elf.STB_WEAK and rhs_sym_bind != elf.STB_GLOBAL) {
+                return true;
+            }
+            return false;
+        }
+    };
+
+    std.sort.sort(u32, aliases, Context{ .object = object }, SortFn.lessThan);
+}
+
+pub fn getString(self: Object, off: u32) []const u8 {
+    assert(off < self.strtab.items.len);
+    return mem.spanZ(@ptrCast([*:0]const u8, self.strtab.items.ptr + off));
+}
+
+/// Caller owns the memory.
+fn readShdrContents(self: Object, allocator: *Allocator, shdr_index: u16) ![]const u8 {
+    const shdr = self.shdrs.items[shdr_index];
+    var buffer = try allocator.alloc(u8, shdr.sh_size);
+    errdefer allocator.free(buffer);
+
+    const offset = self.file_offset orelse 0;
+    const amt = try self.file.preadAll(buffer, shdr.sh_offset + offset);
+    if (amt != buffer.len) {
+        return error.InputOutput;
+    }
+
+    return buffer;
+}

--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -1,0 +1,331 @@
+const Object = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const dwarf = std.dwarf;
+const fs = std.fs;
+const io = std.io;
+const log = std.log.scoped(.macho);
+const macho = std.macho;
+const math = std.math;
+const mem = std.mem;
+const sort = std.sort;
+const commands = @import("commands.zig");
+const segmentName = commands.segmentName;
+const sectionName = commands.sectionName;
+
+const Allocator = mem.Allocator;
+const LoadCommand = commands.LoadCommand;
+
+file: fs.File,
+name: []const u8,
+
+file_offset: ?u32 = null,
+
+header: ?macho.mach_header_64 = null,
+
+load_commands: std.ArrayListUnmanaged(LoadCommand) = .{},
+
+segment_cmd_index: ?u16 = null,
+text_section_index: ?u16 = null,
+symtab_cmd_index: ?u16 = null,
+dysymtab_cmd_index: ?u16 = null,
+build_version_cmd_index: ?u16 = null,
+data_in_code_cmd_index: ?u16 = null,
+
+// __DWARF segment sections
+dwarf_debug_info_index: ?u16 = null,
+dwarf_debug_abbrev_index: ?u16 = null,
+dwarf_debug_str_index: ?u16 = null,
+dwarf_debug_line_index: ?u16 = null,
+dwarf_debug_ranges_index: ?u16 = null,
+
+symtab: std.ArrayListUnmanaged(macho.nlist_64) = .{},
+strtab: std.ArrayListUnmanaged(u8) = .{},
+data_in_code_entries: std.ArrayListUnmanaged(macho.data_in_code_entry) = .{},
+
+// Debug info
+debug_info: ?DebugInfo = null,
+tu_name: ?[]const u8 = null,
+tu_comp_dir: ?[]const u8 = null,
+mtime: ?u64 = null,
+
+sections_as_symbols: std.AutoHashMapUnmanaged(u16, u32) = .{},
+
+// TODO symbol mapping and its inverse can probably be simple arrays
+// instead of hash maps.
+symbol_mapping: std.AutoHashMapUnmanaged(u32, u32) = .{},
+reverse_symbol_mapping: std.AutoHashMapUnmanaged(u32, u32) = .{},
+
+const DebugInfo = struct {
+    inner: dwarf.DwarfInfo,
+    debug_info: []u8,
+    debug_abbrev: []u8,
+    debug_str: []u8,
+    debug_line: []u8,
+    debug_ranges: []u8,
+
+    pub fn parseFromObject(allocator: *Allocator, object: *const Object) !?DebugInfo {
+        var debug_info = blk: {
+            const index = object.dwarf_debug_info_index orelse return null;
+            break :blk try object.readSection(allocator, index);
+        };
+        var debug_abbrev = blk: {
+            const index = object.dwarf_debug_abbrev_index orelse return null;
+            break :blk try object.readSection(allocator, index);
+        };
+        var debug_str = blk: {
+            const index = object.dwarf_debug_str_index orelse return null;
+            break :blk try object.readSection(allocator, index);
+        };
+        var debug_line = blk: {
+            const index = object.dwarf_debug_line_index orelse return null;
+            break :blk try object.readSection(allocator, index);
+        };
+        var debug_ranges = blk: {
+            if (object.dwarf_debug_ranges_index) |ind| {
+                break :blk try object.readSection(allocator, ind);
+            }
+            break :blk try allocator.alloc(u8, 0);
+        };
+
+        var inner: dwarf.DwarfInfo = .{
+            .endian = .Little,
+            .debug_info = debug_info,
+            .debug_abbrev = debug_abbrev,
+            .debug_str = debug_str,
+            .debug_line = debug_line,
+            .debug_ranges = debug_ranges,
+        };
+        try dwarf.openDwarfDebugInfo(&inner, allocator);
+
+        return DebugInfo{
+            .inner = inner,
+            .debug_info = debug_info,
+            .debug_abbrev = debug_abbrev,
+            .debug_str = debug_str,
+            .debug_line = debug_line,
+            .debug_ranges = debug_ranges,
+        };
+    }
+
+    pub fn deinit(self: *DebugInfo, allocator: *Allocator) void {
+        allocator.free(self.debug_info);
+        allocator.free(self.debug_abbrev);
+        allocator.free(self.debug_str);
+        allocator.free(self.debug_line);
+        allocator.free(self.debug_ranges);
+        self.inner.abbrev_table_list.deinit();
+        self.inner.compile_unit_list.deinit();
+        self.inner.func_list.deinit();
+    }
+};
+
+pub fn deinit(self: *Object, allocator: *Allocator) void {
+    for (self.load_commands.items) |*lc| {
+        lc.deinit(allocator);
+    }
+    self.load_commands.deinit(allocator);
+    self.data_in_code_entries.deinit(allocator);
+    self.symtab.deinit(allocator);
+    self.strtab.deinit(allocator);
+    self.sections_as_symbols.deinit(allocator);
+    self.symbol_mapping.deinit(allocator);
+    self.reverse_symbol_mapping.deinit(allocator);
+    allocator.free(self.name);
+
+    if (self.debug_info) |*db| {
+        db.deinit(allocator);
+    }
+
+    if (self.tu_name) |n| {
+        allocator.free(n);
+    }
+
+    if (self.tu_comp_dir) |n| {
+        allocator.free(n);
+    }
+}
+
+pub fn parse(self: *Object, allocator: *Allocator, target: std.Target) !void {
+    const reader = self.file.reader();
+    if (self.file_offset) |offset| {
+        try reader.context.seekTo(offset);
+    }
+
+    const header = try reader.readStruct(macho.mach_header_64);
+    if (header.filetype != macho.MH_OBJECT) {
+        log.debug("invalid filetype: expected 0x{x}, found 0x{x}", .{
+            macho.MH_OBJECT,
+            header.filetype,
+        });
+        return error.NotObject;
+    }
+
+    const this_arch: std.Target.Cpu.Arch = switch (header.cputype) {
+        macho.CPU_TYPE_ARM64 => .aarch64,
+        macho.CPU_TYPE_X86_64 => .x86_64,
+        else => |value| {
+            log.err("unsupported cpu architecture 0x{x}", .{value});
+            return error.UnsupportedCpuArchitecture;
+        },
+    };
+    if (this_arch != target.cpu.arch) {
+        log.err("mismatched cpu architecture: expected {s}, found {s}", .{ target.cpu.arch, this_arch });
+        return error.MismatchedCpuArchitecture;
+    }
+
+    self.header = header;
+
+    try self.readLoadCommands(allocator, reader);
+    try self.parseSymtab(allocator);
+    try self.parseDataInCode(allocator);
+    try self.parseDebugInfo(allocator);
+}
+
+pub fn readLoadCommands(self: *Object, allocator: *Allocator, reader: anytype) !void {
+    const header = self.header orelse unreachable; // Unreachable here signifies a fatal unexplored condition.
+    const offset = self.file_offset orelse 0;
+
+    try self.load_commands.ensureTotalCapacity(allocator, header.ncmds);
+
+    var i: u16 = 0;
+    while (i < header.ncmds) : (i += 1) {
+        var cmd = try LoadCommand.read(allocator, reader);
+        switch (cmd.cmd()) {
+            macho.LC_SEGMENT_64 => {
+                self.segment_cmd_index = i;
+                var seg = cmd.Segment;
+                for (seg.sections.items) |*sect, j| {
+                    const index = @intCast(u16, j);
+                    const segname = segmentName(sect.*);
+                    const sectname = sectionName(sect.*);
+                    if (mem.eql(u8, segname, "__DWARF")) {
+                        if (mem.eql(u8, sectname, "__debug_info")) {
+                            self.dwarf_debug_info_index = index;
+                        } else if (mem.eql(u8, sectname, "__debug_abbrev")) {
+                            self.dwarf_debug_abbrev_index = index;
+                        } else if (mem.eql(u8, sectname, "__debug_str")) {
+                            self.dwarf_debug_str_index = index;
+                        } else if (mem.eql(u8, sectname, "__debug_line")) {
+                            self.dwarf_debug_line_index = index;
+                        } else if (mem.eql(u8, sectname, "__debug_ranges")) {
+                            self.dwarf_debug_ranges_index = index;
+                        }
+                    } else if (mem.eql(u8, segname, "__TEXT")) {
+                        if (mem.eql(u8, sectname, "__text")) {
+                            self.text_section_index = index;
+                        }
+                    }
+
+                    sect.offset += offset;
+                    if (sect.reloff > 0) {
+                        sect.reloff += offset;
+                    }
+                }
+
+                seg.inner.fileoff += offset;
+            },
+            macho.LC_SYMTAB => {
+                self.symtab_cmd_index = i;
+                cmd.Symtab.symoff += offset;
+                cmd.Symtab.stroff += offset;
+            },
+            macho.LC_DYSYMTAB => {
+                self.dysymtab_cmd_index = i;
+            },
+            macho.LC_BUILD_VERSION => {
+                self.build_version_cmd_index = i;
+            },
+            macho.LC_DATA_IN_CODE => {
+                self.data_in_code_cmd_index = i;
+                cmd.LinkeditData.dataoff += offset;
+            },
+            else => {
+                log.debug("Unknown load command detected: 0x{x}.", .{cmd.cmd()});
+            },
+        }
+        self.load_commands.appendAssumeCapacity(cmd);
+    }
+}
+
+fn parseSymtab(self: *Object, allocator: *Allocator) !void {
+    const index = self.symtab_cmd_index orelse return;
+    const symtab_cmd = self.load_commands.items[index].Symtab;
+
+    var symtab = try allocator.alloc(u8, @sizeOf(macho.nlist_64) * symtab_cmd.nsyms);
+    defer allocator.free(symtab);
+    _ = try self.file.preadAll(symtab, symtab_cmd.symoff);
+    const slice = @alignCast(@alignOf(macho.nlist_64), mem.bytesAsSlice(macho.nlist_64, symtab));
+    try self.symtab.appendSlice(allocator, slice);
+
+    var strtab = try allocator.alloc(u8, symtab_cmd.strsize);
+    defer allocator.free(strtab);
+    _ = try self.file.preadAll(strtab, symtab_cmd.stroff);
+    try self.strtab.appendSlice(allocator, strtab);
+}
+
+pub fn parseDebugInfo(self: *Object, allocator: *Allocator) !void {
+    log.debug("parsing debug info in '{s}'", .{self.name});
+
+    var debug_info = blk: {
+        var di = try DebugInfo.parseFromObject(allocator, self);
+        break :blk di orelse return;
+    };
+
+    // We assume there is only one CU.
+    const compile_unit = debug_info.inner.findCompileUnit(0x0) catch |err| switch (err) {
+        error.MissingDebugInfo => {
+            // TODO audit cases with missing debug info and audit our dwarf.zig module.
+            log.debug("invalid or missing debug info in {s}; skipping", .{self.name});
+            return;
+        },
+        else => |e| return e,
+    };
+    const name = try compile_unit.die.getAttrString(&debug_info.inner, dwarf.AT.name);
+    const comp_dir = try compile_unit.die.getAttrString(&debug_info.inner, dwarf.AT.comp_dir);
+
+    self.debug_info = debug_info;
+    self.tu_name = try allocator.dupe(u8, name);
+    self.tu_comp_dir = try allocator.dupe(u8, comp_dir);
+
+    if (self.mtime == null) {
+        self.mtime = mtime: {
+            const stat = self.file.stat() catch break :mtime 0;
+            break :mtime @intCast(u64, @divFloor(stat.mtime, 1_000_000_000));
+        };
+    }
+}
+
+pub fn parseDataInCode(self: *Object, allocator: *Allocator) !void {
+    const index = self.data_in_code_cmd_index orelse return;
+    const data_in_code = self.load_commands.items[index].LinkeditData;
+
+    var buffer = try allocator.alloc(u8, data_in_code.datasize);
+    defer allocator.free(buffer);
+
+    _ = try self.file.preadAll(buffer, data_in_code.dataoff);
+
+    var stream = io.fixedBufferStream(buffer);
+    var reader = stream.reader();
+    while (true) {
+        const dice = reader.readStruct(macho.data_in_code_entry) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => |e| return e,
+        };
+        try self.data_in_code_entries.append(allocator, dice);
+    }
+}
+
+fn readSection(self: Object, allocator: *Allocator, index: u16) ![]u8 {
+    const seg = self.load_commands.items[self.segment_cmd_index.?].Segment;
+    const sect = seg.sections.items[index];
+    var buffer = try allocator.alloc(u8, @intCast(usize, sect.size));
+    _ = try self.file.preadAll(buffer, sect.offset);
+    return buffer;
+}
+
+pub fn getString(self: Object, off: u32) []const u8 {
+    assert(off < self.strtab.items.len);
+    return mem.spanZ(@ptrCast([*:0]const u8, self.strtab.items.ptr + off));
+}

--- a/src/link/MachO/commands.zig
+++ b/src/link/MachO/commands.zig
@@ -1,0 +1,575 @@
+const std = @import("std");
+const fs = std.fs;
+const io = std.io;
+const mem = std.mem;
+const meta = std.meta;
+const macho = std.macho;
+const testing = std.testing;
+const assert = std.debug.assert;
+
+const Allocator = std.mem.Allocator;
+// const MachO = @import("../MachO.zig");
+
+pub const HeaderArgs = struct {
+    magic: u32 = macho.MH_MAGIC_64,
+    cputype: macho.cpu_type_t = 0,
+    cpusubtype: macho.cpu_subtype_t = 0,
+    filetype: u32 = 0,
+    flags: u32 = 0,
+    reserved: u32 = 0,
+};
+
+pub fn emptyHeader(args: HeaderArgs) macho.mach_header_64 {
+    return .{
+        .magic = args.magic,
+        .cputype = args.cputype,
+        .cpusubtype = args.cpusubtype,
+        .filetype = args.filetype,
+        .ncmds = 0,
+        .sizeofcmds = 0,
+        .flags = args.flags,
+        .reserved = args.reserved,
+    };
+}
+
+pub const LoadCommand = union(enum) {
+    Segment: SegmentCommand,
+    DyldInfoOnly: macho.dyld_info_command,
+    Symtab: macho.symtab_command,
+    Dysymtab: macho.dysymtab_command,
+    Dylinker: GenericCommandWithData(macho.dylinker_command),
+    Dylib: GenericCommandWithData(macho.dylib_command),
+    Main: macho.entry_point_command,
+    VersionMin: macho.version_min_command,
+    SourceVersion: macho.source_version_command,
+    BuildVersion: GenericCommandWithData(macho.build_version_command),
+    Uuid: macho.uuid_command,
+    LinkeditData: macho.linkedit_data_command,
+    Rpath: GenericCommandWithData(macho.rpath_command),
+    Unknown: GenericCommandWithData(macho.load_command),
+
+    pub fn read(allocator: *Allocator, reader: anytype) !LoadCommand {
+        const header = try reader.readStruct(macho.load_command);
+        var buffer = try allocator.alloc(u8, header.cmdsize);
+        defer allocator.free(buffer);
+        mem.copy(u8, buffer, mem.asBytes(&header));
+        try reader.readNoEof(buffer[@sizeOf(macho.load_command)..]);
+        var stream = io.fixedBufferStream(buffer);
+
+        return switch (header.cmd) {
+            macho.LC_SEGMENT_64 => LoadCommand{
+                .Segment = try SegmentCommand.read(allocator, stream.reader()),
+            },
+            macho.LC_DYLD_INFO,
+            macho.LC_DYLD_INFO_ONLY,
+            => LoadCommand{
+                .DyldInfoOnly = try stream.reader().readStruct(macho.dyld_info_command),
+            },
+            macho.LC_SYMTAB => LoadCommand{
+                .Symtab = try stream.reader().readStruct(macho.symtab_command),
+            },
+            macho.LC_DYSYMTAB => LoadCommand{
+                .Dysymtab = try stream.reader().readStruct(macho.dysymtab_command),
+            },
+            macho.LC_ID_DYLINKER,
+            macho.LC_LOAD_DYLINKER,
+            macho.LC_DYLD_ENVIRONMENT,
+            => LoadCommand{
+                .Dylinker = try GenericCommandWithData(macho.dylinker_command).read(allocator, stream.reader()),
+            },
+            macho.LC_ID_DYLIB,
+            macho.LC_LOAD_WEAK_DYLIB,
+            macho.LC_LOAD_DYLIB,
+            macho.LC_REEXPORT_DYLIB,
+            => LoadCommand{
+                .Dylib = try GenericCommandWithData(macho.dylib_command).read(allocator, stream.reader()),
+            },
+            macho.LC_MAIN => LoadCommand{
+                .Main = try stream.reader().readStruct(macho.entry_point_command),
+            },
+            macho.LC_VERSION_MIN_MACOSX,
+            macho.LC_VERSION_MIN_IPHONEOS,
+            macho.LC_VERSION_MIN_WATCHOS,
+            macho.LC_VERSION_MIN_TVOS,
+            => LoadCommand{
+                .VersionMin = try stream.reader().readStruct(macho.version_min_command),
+            },
+            macho.LC_SOURCE_VERSION => LoadCommand{
+                .SourceVersion = try stream.reader().readStruct(macho.source_version_command),
+            },
+            macho.LC_BUILD_VERSION => LoadCommand{
+                .BuildVersion = try GenericCommandWithData(macho.build_version_command).read(allocator, stream.reader()),
+            },
+            macho.LC_UUID => LoadCommand{
+                .Uuid = try stream.reader().readStruct(macho.uuid_command),
+            },
+            macho.LC_FUNCTION_STARTS,
+            macho.LC_DATA_IN_CODE,
+            macho.LC_CODE_SIGNATURE,
+            => LoadCommand{
+                .LinkeditData = try stream.reader().readStruct(macho.linkedit_data_command),
+            },
+            macho.LC_RPATH => LoadCommand{
+                .Rpath = try GenericCommandWithData(macho.rpath_command).read(allocator, stream.reader()),
+            },
+            else => LoadCommand{
+                .Unknown = try GenericCommandWithData(macho.load_command).read(allocator, stream.reader()),
+            },
+        };
+    }
+
+    pub fn write(self: LoadCommand, writer: anytype) !void {
+        return switch (self) {
+            .DyldInfoOnly => |x| writeStruct(x, writer),
+            .Symtab => |x| writeStruct(x, writer),
+            .Dysymtab => |x| writeStruct(x, writer),
+            .Main => |x| writeStruct(x, writer),
+            .VersionMin => |x| writeStruct(x, writer),
+            .SourceVersion => |x| writeStruct(x, writer),
+            .Uuid => |x| writeStruct(x, writer),
+            .LinkeditData => |x| writeStruct(x, writer),
+            .Segment => |x| x.write(writer),
+            .Dylinker => |x| x.write(writer),
+            .Dylib => |x| x.write(writer),
+            .Rpath => |x| x.write(writer),
+            .BuildVersion => |x| x.write(writer),
+            .Unknown => |x| x.write(writer),
+        };
+    }
+
+    pub fn cmd(self: LoadCommand) u32 {
+        return switch (self) {
+            .DyldInfoOnly => |x| x.cmd,
+            .Symtab => |x| x.cmd,
+            .Dysymtab => |x| x.cmd,
+            .Main => |x| x.cmd,
+            .VersionMin => |x| x.cmd,
+            .SourceVersion => |x| x.cmd,
+            .Uuid => |x| x.cmd,
+            .LinkeditData => |x| x.cmd,
+            .Segment => |x| x.inner.cmd,
+            .Dylinker => |x| x.inner.cmd,
+            .Dylib => |x| x.inner.cmd,
+            .Rpath => |x| x.inner.cmd,
+            .BuildVersion => |x| x.inner.cmd,
+            .Unknown => |x| x.inner.cmd,
+        };
+    }
+
+    pub fn cmdsize(self: LoadCommand) u32 {
+        return switch (self) {
+            .DyldInfoOnly => |x| x.cmdsize,
+            .Symtab => |x| x.cmdsize,
+            .Dysymtab => |x| x.cmdsize,
+            .Main => |x| x.cmdsize,
+            .VersionMin => |x| x.cmdsize,
+            .SourceVersion => |x| x.cmdsize,
+            .LinkeditData => |x| x.cmdsize,
+            .Uuid => |x| x.cmdsize,
+            .Segment => |x| x.inner.cmdsize,
+            .Dylinker => |x| x.inner.cmdsize,
+            .Dylib => |x| x.inner.cmdsize,
+            .Rpath => |x| x.inner.cmdsize,
+            .BuildVersion => |x| x.inner.cmdsize,
+            .Unknown => |x| x.inner.cmdsize,
+        };
+    }
+
+    pub fn deinit(self: *LoadCommand, allocator: *Allocator) void {
+        return switch (self.*) {
+            .Segment => |*x| x.deinit(allocator),
+            .Dylinker => |*x| x.deinit(allocator),
+            .Dylib => |*x| x.deinit(allocator),
+            .Rpath => |*x| x.deinit(allocator),
+            .BuildVersion => |*x| x.deinit(allocator),
+            .Unknown => |*x| x.deinit(allocator),
+            else => {},
+        };
+    }
+
+    fn writeStruct(command: anytype, writer: anytype) !void {
+        return writer.writeAll(mem.asBytes(&command));
+    }
+
+    fn eql(self: LoadCommand, other: LoadCommand) bool {
+        if (@as(meta.Tag(LoadCommand), self) != @as(meta.Tag(LoadCommand), other)) return false;
+        return switch (self) {
+            .DyldInfoOnly => |x| meta.eql(x, other.DyldInfoOnly),
+            .Symtab => |x| meta.eql(x, other.Symtab),
+            .Dysymtab => |x| meta.eql(x, other.Dysymtab),
+            .Main => |x| meta.eql(x, other.Main),
+            .VersionMin => |x| meta.eql(x, other.VersionMin),
+            .SourceVersion => |x| meta.eql(x, other.SourceVersion),
+            .BuildVersion => |x| x.eql(other.BuildVersion),
+            .Uuid => |x| meta.eql(x, other.Uuid),
+            .LinkeditData => |x| meta.eql(x, other.LinkeditData),
+            .Segment => |x| x.eql(other.Segment),
+            .Dylinker => |x| x.eql(other.Dylinker),
+            .Dylib => |x| x.eql(other.Dylib),
+            .Rpath => |x| x.eql(other.Rpath),
+            .Unknown => |x| x.eql(other.Unknown),
+        };
+    }
+};
+
+pub const SegmentCommand = struct {
+    inner: macho.segment_command_64,
+    sections: std.ArrayListUnmanaged(macho.section_64) = .{},
+
+    const SegmentOptions = struct {
+        cmdsize: u32 = @sizeOf(macho.segment_command_64),
+        vmaddr: u64 = 0,
+        vmsize: u64 = 0,
+        fileoff: u64 = 0,
+        filesize: u64 = 0,
+        maxprot: macho.vm_prot_t = macho.VM_PROT_NONE,
+        initprot: macho.vm_prot_t = macho.VM_PROT_NONE,
+        nsects: u32 = 0,
+        flags: u32 = 0,
+    };
+
+    pub fn empty(comptime segname: []const u8, opts: SegmentOptions) SegmentCommand {
+        return .{
+            .inner = .{
+                .cmd = macho.LC_SEGMENT_64,
+                .cmdsize = opts.cmdsize,
+                .segname = makeStaticString(segname),
+                .vmaddr = opts.vmaddr,
+                .vmsize = opts.vmsize,
+                .fileoff = opts.fileoff,
+                .filesize = opts.filesize,
+                .maxprot = opts.maxprot,
+                .initprot = opts.initprot,
+                .nsects = opts.nsects,
+                .flags = opts.flags,
+            },
+        };
+    }
+
+    const SectionOptions = struct {
+        addr: u64 = 0,
+        size: u64 = 0,
+        offset: u32 = 0,
+        @"align": u32 = 0,
+        reloff: u32 = 0,
+        nreloc: u32 = 0,
+        flags: u32 = macho.S_REGULAR,
+        reserved1: u32 = 0,
+        reserved2: u32 = 0,
+        reserved3: u32 = 0,
+    };
+
+    pub fn addSection(
+        self: *SegmentCommand,
+        alloc: *Allocator,
+        comptime sectname: []const u8,
+        opts: SectionOptions,
+    ) !void {
+        var section = macho.section_64{
+            .sectname = makeStaticString(sectname),
+            .segname = undefined,
+            .addr = opts.addr,
+            .size = opts.size,
+            .offset = opts.offset,
+            .@"align" = opts.@"align",
+            .reloff = opts.reloff,
+            .nreloc = opts.nreloc,
+            .flags = opts.flags,
+            .reserved1 = opts.reserved1,
+            .reserved2 = opts.reserved2,
+            .reserved3 = opts.reserved3,
+        };
+        mem.copy(u8, &section.segname, &self.inner.segname);
+        try self.sections.append(alloc, section);
+        self.inner.cmdsize += @sizeOf(macho.section_64);
+        self.inner.nsects += 1;
+    }
+
+    pub fn read(alloc: *Allocator, reader: anytype) !SegmentCommand {
+        const inner = try reader.readStruct(macho.segment_command_64);
+        var segment = SegmentCommand{
+            .inner = inner,
+        };
+        try segment.sections.ensureCapacity(alloc, inner.nsects);
+
+        var i: usize = 0;
+        while (i < inner.nsects) : (i += 1) {
+            const section = try reader.readStruct(macho.section_64);
+            segment.sections.appendAssumeCapacity(section);
+        }
+
+        return segment;
+    }
+
+    pub fn write(self: SegmentCommand, writer: anytype) !void {
+        try writer.writeAll(mem.asBytes(&self.inner));
+        for (self.sections.items) |sect| {
+            try writer.writeAll(mem.asBytes(&sect));
+        }
+    }
+
+    pub fn deinit(self: *SegmentCommand, alloc: *Allocator) void {
+        self.sections.deinit(alloc);
+    }
+
+    fn eql(self: SegmentCommand, other: SegmentCommand) bool {
+        if (!meta.eql(self.inner, other.inner)) return false;
+        const lhs = self.sections.items;
+        const rhs = other.sections.items;
+        var i: usize = 0;
+        while (i < self.inner.nsects) : (i += 1) {
+            if (!meta.eql(lhs[i], rhs[i])) return false;
+        }
+        return true;
+    }
+};
+
+pub fn emptyGenericCommandWithData(cmd: anytype) GenericCommandWithData(@TypeOf(cmd)) {
+    return .{ .inner = cmd };
+}
+
+pub fn GenericCommandWithData(comptime Cmd: type) type {
+    return struct {
+        inner: Cmd,
+        /// This field remains undefined until `read` is called.
+        data: []u8 = undefined,
+
+        const Self = @This();
+
+        pub fn read(allocator: *Allocator, reader: anytype) !Self {
+            const inner = try reader.readStruct(Cmd);
+            var data = try allocator.alloc(u8, inner.cmdsize - @sizeOf(Cmd));
+            errdefer allocator.free(data);
+            try reader.readNoEof(data);
+            return Self{
+                .inner = inner,
+                .data = data,
+            };
+        }
+
+        pub fn write(self: Self, writer: anytype) !void {
+            try writer.writeAll(mem.asBytes(&self.inner));
+            try writer.writeAll(self.data);
+        }
+
+        pub fn deinit(self: *Self, allocator: *Allocator) void {
+            allocator.free(self.data);
+        }
+
+        fn eql(self: Self, other: Self) bool {
+            if (!meta.eql(self.inner, other.inner)) return false;
+            return mem.eql(u8, self.data, other.data);
+        }
+    };
+}
+
+pub fn createLoadDylibCommand(
+    allocator: *Allocator,
+    name: []const u8,
+    timestamp: u32,
+    current_version: u32,
+    compatibility_version: u32,
+) !GenericCommandWithData(macho.dylib_command) {
+    const cmdsize = @intCast(u32, mem.alignForwardGeneric(
+        u64,
+        @sizeOf(macho.dylib_command) + name.len + 1, // +1 for nul
+        @sizeOf(u64),
+    ));
+
+    var dylib_cmd = emptyGenericCommandWithData(macho.dylib_command{
+        .cmd = macho.LC_LOAD_DYLIB,
+        .cmdsize = cmdsize,
+        .dylib = .{
+            .name = @sizeOf(macho.dylib_command),
+            .timestamp = timestamp,
+            .current_version = current_version,
+            .compatibility_version = compatibility_version,
+        },
+    });
+    dylib_cmd.data = try allocator.alloc(u8, cmdsize - dylib_cmd.inner.dylib.name);
+
+    mem.set(u8, dylib_cmd.data, 0);
+    mem.copy(u8, dylib_cmd.data, name);
+
+    return dylib_cmd;
+}
+
+fn makeStaticString(bytes: []const u8) [16]u8 {
+    var buf = [_]u8{0} ** 16;
+    assert(bytes.len <= buf.len);
+    mem.copy(u8, &buf, bytes);
+    return buf;
+}
+
+fn parseName(name: *const [16]u8) []const u8 {
+    const len = mem.indexOfScalar(u8, name, @as(u8, 0)) orelse name.len;
+    return name[0..len];
+}
+
+pub fn segmentName(sect: macho.section_64) []const u8 {
+    return parseName(&sect.segname);
+}
+
+pub fn sectionName(sect: macho.section_64) []const u8 {
+    return parseName(&sect.sectname);
+}
+
+pub fn sectionType(sect: macho.section_64) u8 {
+    return @truncate(u8, sect.flags & 0xff);
+}
+
+pub fn sectionAttrs(sect: macho.section_64) u32 {
+    return sect.flags & 0xffffff00;
+}
+
+pub fn sectionIsCode(sect: macho.section_64) bool {
+    const attr = sectionAttrs(sect);
+    return attr & macho.S_ATTR_PURE_INSTRUCTIONS != 0 or attr & macho.S_ATTR_SOME_INSTRUCTIONS != 0;
+}
+
+pub fn sectionIsDebug(sect: macho.section_64) bool {
+    return sectionAttrs(sect) & macho.S_ATTR_DEBUG != 0;
+}
+
+pub fn sectionIsDontDeadStrip(sect: macho.section_64) bool {
+    return sectionAttrs(sect) & macho.S_ATTR_NO_DEAD_STRIP != 0;
+}
+
+pub fn sectionIsDontDeadStripIfReferencesLive(sect: macho.section_64) bool {
+    return sectionAttrs(sect) & macho.S_ATTR_LIVE_SUPPORT != 0;
+}
+
+fn testRead(allocator: *Allocator, buffer: []const u8, expected: anytype) !void {
+    var stream = io.fixedBufferStream(buffer);
+    var given = try LoadCommand.read(allocator, stream.reader());
+    defer given.deinit(allocator);
+    try testing.expect(expected.eql(given));
+}
+
+fn testWrite(buffer: []u8, cmd: LoadCommand, expected: []const u8) !void {
+    var stream = io.fixedBufferStream(buffer);
+    try cmd.write(stream.writer());
+    try testing.expect(mem.eql(u8, expected, buffer[0..expected.len]));
+}
+
+test "read-write segment command" {
+    var gpa = testing.allocator;
+    const in_buffer = &[_]u8{
+        0x19, 0x00, 0x00, 0x00, // cmd
+        0x98, 0x00, 0x00, 0x00, // cmdsize
+        0x5f, 0x5f, 0x54, 0x45, 0x58, 0x54, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // segname
+        0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, // vmaddr
+        0x00, 0x80, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, // vmsize
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // fileoff
+        0x00, 0x80, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, // filesize
+        0x07, 0x00, 0x00, 0x00, // maxprot
+        0x05, 0x00, 0x00, 0x00, // initprot
+        0x01, 0x00, 0x00, 0x00, // nsects
+        0x00, 0x00, 0x00, 0x00, // flags
+        0x5f, 0x5f, 0x74, 0x65, 0x78, 0x74, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sectname
+        0x5f, 0x5f, 0x54, 0x45, 0x58, 0x54, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // segname
+        0x00, 0x40, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, // address
+        0xc0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // size
+        0x00, 0x40, 0x00, 0x00, // offset
+        0x02, 0x00, 0x00, 0x00, // alignment
+        0x00, 0x00, 0x00, 0x00, // reloff
+        0x00, 0x00, 0x00, 0x00, // nreloc
+        0x00, 0x04, 0x00, 0x80, // flags
+        0x00, 0x00, 0x00, 0x00, // reserved1
+        0x00, 0x00, 0x00, 0x00, // reserved2
+        0x00, 0x00, 0x00, 0x00, // reserved3
+    };
+    var cmd = SegmentCommand{
+        .inner = .{
+            .cmd = macho.LC_SEGMENT_64,
+            .cmdsize = 152,
+            .segname = makeStaticString("__TEXT"),
+            .vmaddr = 4294967296,
+            .vmsize = 294912,
+            .fileoff = 0,
+            .filesize = 294912,
+            .maxprot = macho.VM_PROT_READ | macho.VM_PROT_WRITE | macho.VM_PROT_EXECUTE,
+            .initprot = macho.VM_PROT_EXECUTE | macho.VM_PROT_READ,
+            .nsects = 1,
+            .flags = 0,
+        },
+    };
+    try cmd.sections.append(gpa, .{
+        .sectname = makeStaticString("__text"),
+        .segname = makeStaticString("__TEXT"),
+        .addr = 4294983680,
+        .size = 448,
+        .offset = 16384,
+        .@"align" = 2,
+        .reloff = 0,
+        .nreloc = 0,
+        .flags = macho.S_REGULAR | macho.S_ATTR_PURE_INSTRUCTIONS | macho.S_ATTR_SOME_INSTRUCTIONS,
+        .reserved1 = 0,
+        .reserved2 = 0,
+        .reserved3 = 0,
+    });
+    defer cmd.deinit(gpa);
+    try testRead(gpa, in_buffer, LoadCommand{ .Segment = cmd });
+
+    var out_buffer: [in_buffer.len]u8 = undefined;
+    try testWrite(&out_buffer, LoadCommand{ .Segment = cmd }, in_buffer);
+}
+
+test "read-write generic command with data" {
+    var gpa = testing.allocator;
+    const in_buffer = &[_]u8{
+        0x0c, 0x00, 0x00, 0x00, // cmd
+        0x20, 0x00, 0x00, 0x00, // cmdsize
+        0x18, 0x00, 0x00, 0x00, // name
+        0x02, 0x00, 0x00, 0x00, // timestamp
+        0x00, 0x00, 0x00, 0x00, // current_version
+        0x00, 0x00, 0x00, 0x00, // compatibility_version
+        0x2f, 0x75, 0x73, 0x72, 0x00, 0x00, 0x00, 0x00, // data
+    };
+    var cmd = GenericCommandWithData(macho.dylib_command){
+        .inner = .{
+            .cmd = macho.LC_LOAD_DYLIB,
+            .cmdsize = 32,
+            .dylib = .{
+                .name = 24,
+                .timestamp = 2,
+                .current_version = 0,
+                .compatibility_version = 0,
+            },
+        },
+    };
+    cmd.data = try gpa.alloc(u8, 8);
+    defer gpa.free(cmd.data);
+    cmd.data[0] = 0x2f;
+    cmd.data[1] = 0x75;
+    cmd.data[2] = 0x73;
+    cmd.data[3] = 0x72;
+    cmd.data[4] = 0x0;
+    cmd.data[5] = 0x0;
+    cmd.data[6] = 0x0;
+    cmd.data[7] = 0x0;
+    try testRead(gpa, in_buffer, LoadCommand{ .Dylib = cmd });
+
+    var out_buffer: [in_buffer.len]u8 = undefined;
+    try testWrite(&out_buffer, LoadCommand{ .Dylib = cmd }, in_buffer);
+}
+
+test "read-write C struct command" {
+    var gpa = testing.allocator;
+    const in_buffer = &[_]u8{
+        0x28, 0x00, 0x00, 0x80, // cmd
+        0x18, 0x00, 0x00, 0x00, // cmdsize
+        0x04, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // entryoff
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // stacksize
+    };
+    const cmd = .{
+        .cmd = macho.LC_MAIN,
+        .cmdsize = 24,
+        .entryoff = 16644,
+        .stacksize = 0,
+    };
+    try testRead(gpa, in_buffer, LoadCommand{ .Main = cmd });
+
+    var out_buffer: [in_buffer.len]u8 = undefined;
+    try testWrite(&out_buffer, LoadCommand{ .Main = cmd }, in_buffer);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -199,6 +199,8 @@ pub fn main() anyerror!void {
                 'U' => modifiers.use_real_timestamps_and_ids = true,
                 'D' => modifiers.use_real_timestamps_and_ids = false,
                 'v' => modifiers.verbose = true,
+                's' => modifiers.build_symbol_table = true,
+                'S' => modifiers.build_symbol_table = false,
                 // TODO: should we print warning with unknown modifier?
                 else => {},
             }


### PR DESCRIPTION
This PR adds symbol table for
- ELF & MachO object files
- in GNU, GNU64, Thin, BSD and Darwin64 format
- s and S modifiers
- (includes code from zld)

