### PR TITLE
Improve error handling

### DIFF
--- a/src/test.zig
+++ b/src/test.zig
@@ -55,11 +55,9 @@ fn testFileContents(test_dir_path: []const u8, archive_name: []const u8, file_na
     defer arena.deinit();
 
     var allocator = &arena.allocator;
-    // TODO: pass through custom writer so we can check outputs on error tests
-    const stderr = io.getStdErr().writer();
 
     var archive = try Archive.create(archive_file, archive_name, Archive.ArchiveType.ambiguous, .{});
-    try archive.parse(allocator, stderr);
+    try archive.parse(allocator);
 
     var memory_buffer = try allocator.alloc(u8, 1024 * 1024);
     for (file_names) |file_name, index| {


### PR DESCRIPTION
This change in complete, currently in proof-of-concept stage.

Creates a new error set for non-program errors, i.e. errors caused by
dodgy input (malformed archives) as opposed to programming mistakes or
runtime issues.

Seperate-out printing to stderr (now done in main.zig) from producing
errors when parsing & formatting useful error strings.

The intent here is to make archive parsing more usable as an API, and
eventually capture & return more kinds of errors.

Top-level error handling for program errors (eg. OOM) to come after we
decide how to handle these kinds of errors.