### PR TITLE
Add support for writing sorted symbol table

### DIFF
--- a/src/archive/Archive.zig
+++ b/src/archive/Archive.zig
@@ -146,6 +146,7 @@ pub const Modifiers = extern struct {
     update_only: bool = false,
     use_real_timestamps_and_ids: bool = false,
     build_symbol_table: bool = true,
+    sort_symbol_table: bool = true,
     verbose: bool = false,
 };
 
@@ -264,8 +265,10 @@ pub fn finalize(self: *Archive, allocator: *Allocator) !void {
     };
     
     // Sort the symbols
-    std.sort.sort(Symbol, self.symbols.items, {}, SortFn.sorter);
-
+    if (self.modifiers.sort_symbol_table) {
+        std.sort.sort(Symbol, self.symbols.items, {}, SortFn.sorter);
+    }
+        
     // Create common symbol table information
     var symbol_count: u32 = 0;
     var symbol_table = std.ArrayList(u8).init(allocator);

--- a/src/archive/Archive.zig
+++ b/src/archive/Archive.zig
@@ -254,6 +254,17 @@ pub fn finalize(self: *Archive, allocator: *Allocator) !void {
     try writer.writeAll(if (self.output_archive_type == .gnuthin) magic_thin else magic_string);
 
     const header_names = try allocator.alloc([16]u8, self.files.items.len);
+    
+    // Symbol sorting function
+    const SortFn = struct {
+        fn sorter(context: void, x: Symbol, y: Symbol) bool {
+            _ = context;
+            return std.mem.lessThan(u8, x.name, y.name);
+        }        
+    };
+    
+    // Sort the symbols
+    std.sort.sort(Symbol, self.symbols.items, {}, SortFn.sorter);
 
     // Create common symbol table information
     var symbol_count: u32 = 0;

--- a/src/main.zig
+++ b/src/main.zig
@@ -44,7 +44,8 @@ const overview =
     \\     S: show file names that symbols belong to.
     \\ s - Generate symbol table
     \\ S - Do not generate symbol table
-    \\ R - Create sorted symbol table (zar specific)
+    \\ r - Create sorted symbol table
+    \\ R - Do not create sorted symbol table
     \\
     \\Note, in the case of conflicting modifiers, the last one listed always takes precedence.
     \\
@@ -247,7 +248,8 @@ pub fn archiveMain() anyerror!void {
                 'v' => modifiers.verbose = true,
                 's' => modifiers.build_symbol_table = true,
                 'S' => modifiers.build_symbol_table = false,
-                'R' => modifiers.sort_symbol_table = true,
+                'r' => modifiers.sort_symbol_table = true,
+                'R' => modifiers.sort_symbol_table = false,
                 // TODO: should we print warning with unknown modifier?
                 else => {},
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -244,6 +244,7 @@ pub fn archiveMain() anyerror!void {
                 'v' => modifiers.verbose = true,
                 's' => modifiers.build_symbol_table = true,
                 'S' => modifiers.build_symbol_table = false,
+                'o' => modifiers.sort_symbol_table = true,
                 // TODO: should we print warning with unknown modifier?
                 else => {},
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,6 +42,9 @@ const overview =
     \\ U - Use real timestamps, GIDS and UIDs for archived files.
     \\ v - Print verbose output, depending on opertion:
     \\     S: show file names that symbols belong to.
+    \\ s - Generate symbol table
+    \\ S - Do not generate symbol table
+    \\ R - Create sorted symbol table (zar specific)
     \\
     \\Note, in the case of conflicting modifiers, the last one listed always takes precedence.
     \\
@@ -244,7 +247,7 @@ pub fn archiveMain() anyerror!void {
                 'v' => modifiers.verbose = true,
                 's' => modifiers.build_symbol_table = true,
                 'S' => modifiers.build_symbol_table = false,
-                'o' => modifiers.sort_symbol_table = true,
+                'R' => modifiers.sort_symbol_table = true,
                 // TODO: should we print warning with unknown modifier?
                 else => {},
             }


### PR DESCRIPTION
This tiny PR adds support for sorted symbol table which could be useful for darwin or windows ecoff symbol table in future. Currently it is exposed as a non-standard zar-specific extension modifier to create command.

Also, sorting of table is enabled by default as the option is harmless even when a sorted table is not expected.