### PR TITLE
Matching llvm-ar output for GNU format

### DIFF
--- a/src/archive/Archive.zig
+++ b/src/archive/Archive.zig
@@ -150,7 +150,7 @@ pub const Modifiers = extern struct {
     update_only: bool = false,
     use_real_timestamps_and_ids: bool = false,
     build_symbol_table: bool = true,
-    sort_symbol_table: bool = true,
+    sort_symbol_table: bool = false,
     verbose: bool = false,
 };
 

--- a/src/archive/Archive.zig
+++ b/src/archive/Archive.zig
@@ -319,6 +319,9 @@ pub fn finalize(self: *Archive, allocator: *Allocator) !void {
         symbols[idx].file_offset = file_offset[symbol.file_index];
     }
 
+    // Set the mtime of symbol table to now seconds in non-deterministic mode
+    const symtab_time: u64 = (if (self.modifiers.use_real_timestamps_and_ids) @intCast(u64, std.time.milliTimestamp()) else 0) / 1000;
+
     switch (self.output_archive_type) {
         .gnu, .gnuthin, .gnu64 => {
             // GNU format: Create string table
@@ -363,7 +366,7 @@ pub fn finalize(self: *Archive, allocator: *Allocator) !void {
 
                     const magic: []const u8 = if (format == .gnu64) "/SYM64/" else "/";
 
-                    try writer.print(Header.format_string, .{ magic, 0, 0, 0, 0, symbol_table_size });
+                    try writer.print(Header.format_string, .{ magic, symtab_time, 0, 0, 0, symbol_table_size });
 
                     if (format == .gnu64) {
                         try writer.writeIntBig(u64, @intCast(u64, symbols.len));
@@ -415,7 +418,7 @@ pub fn finalize(self: *Archive, allocator: *Allocator) !void {
                     int_size + // Int describing size of symbol table's strings
                     symbol_table.items.len; // The lengths of strings themselves
 
-                try writer.print(Header.format_string, .{ "#1/12", 0, 0, 0, 0, symbol_table_size });
+                try writer.print(Header.format_string, .{ "#1/12", symtab_time, 0, 0, 0, symbol_table_size });
 
                 const endian = builtin.cpu.arch.endian();
 


### PR DESCRIPTION
This PR makes some changes which now allows zar to generate archives which are compatible with llvm-ar generated archives.
This is only true for GNU format right now as BSD format needs additional offset tricks (BSD is align 8 vs GNU is align 2 which is performed for both right now)

Solutions may not be perfect (especially regarding file mode). Need additional real life testing for that.

Partially addresses #35 

This PR unblocks writing tests (only for GNU format), which was previously not possible at all.

Issues with BSD would be addressed in a different PR as my goal is to do a thorough split up of finalize() function into multiple parts so as to do cleanup the mess of this function.