### PR TITLE
Add test that builds redis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
                   ref: moosichu/test-zar
                   path: redis
             - name: Build Redis With Zar
-              run: make CC="zig cc" CXX="zig c++" AR="../zig-out/bin/zar" USE_JEMALLOC=no USE_SYSTEMD=no
+              run: make CC="zig cc" CXX="zig c++" AR="${GITHUB_WORKSPACE}/zig-out/bin/zar" USE_JEMALLOC=no USE_SYSTEMD=no
               working-directory: redis
         
               

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-latest, macos-latest, windows-latest]
+                os: [ubuntu-latest, macos-latest]
                 
         steps:
             - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,32 @@ jobs:
               run: zig build
             - name: Test
               run: zig build test
+    test_redis:
+        name: Test Redis
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest, macos-latest, windows-latest]
+                
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2.4.2
+              with:
+                  submodules: recursive
+            - name: Setup Zig
+              uses: goto-bus-stop/setup-zig@v1
+              with:
+                  version: master
+            - name: Build
+              run: zig build
+            - name: Fetch Redis
+              uses: actions/checkout@v2.4.2
+              with:
+                  name: moosichu/redis
+                  ref: moosichu/test-zar
+                  path: redis
+            - name: Test Redis
+              run: make CC="zig cc" CXX="zig c++" AR="../zig-out/bin/zar"
+              working-directory: redis
+        
+              

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Fetch Redis
               uses: actions/checkout@v2.4.2
               with:
-                  name: moosichu/redis
+                  repository: moosichu/redis
                   ref: moosichu/test-zar
                   path: redis
             - name: Test Redis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
                   repository: moosichu/redis
                   ref: moosichu/test-zar
                   path: redis
-            - name: Test Redis
-              run: make CC="zig cc" CXX="zig c++" AR="../zig-out/bin/zar"
+            - name: Build Redis With Zar
+              run: make CC="zig cc" CXX="zig c++" AR="../zig-out/bin/zar" USE_JEMALLOC=no USE_SYSTEMD=no
               working-directory: redis
         
               


### PR DESCRIPTION
This patch should add a GitHub action that adds a redis-building test.

This contributes towards #42, but just has same-platform compiling (not cross-compiling yet)