### PR TITLE
Ensure all IO errors are exhaustively handled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,21 @@ jobs:
       - name: Build Redis macOS
         run: make CC="zig cc -target x86_64-macos" CXX="zig c++ -target x86_64-macos" AR="${GITHUB_WORKSPACE}/zig-out/bin/zar" RANLIB="zig ranlib" uname_S="Darwin" uname_M="x86_64" USE_JEMALLOC=no USE_SYSTEMD=no
         working-directory: redis
+  test_io_errors_handled:
+    name: Test handled errors are actually handled
+    timeout-minutes: 15
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: master
+      - name: Build
+        run: zig build -Dtest-errors-handled=true

--- a/build.zig
+++ b/build.zig
@@ -30,6 +30,9 @@ pub fn build(b: *std.build.Builder) void {
     tests.addOptions("build_options", exe_options);
     tests_exe.addOptions("build_options", exe_options);
 
+    const test_errors_handled = b.option(bool, "test-errors-handled", "Compile with this to confirm zar sends all io errors through the io error handler") orelse false;
+    exe_options.addOption(bool, "test_errors_handled", test_errors_handled);
+
     {
         const tracy = b.option([]const u8, "tracy", "Enable Tracy integration. Supply path to Tracy source");
         const tracy_callstack = b.option(bool, "tracy-callstack", "Include callstack information with Tracy data. Does nothing if -Dtracy is not provided") orelse false;

--- a/src/main.zig
+++ b/src/main.zig
@@ -160,8 +160,7 @@ fn openOrCreateFile(cwd: fs.Dir, archive_path: []const u8, print_creation_warnin
             return create_file_handle;
         },
         else => {
-            Archive.printFileIoError(.opening, archive_path, err);
-            return err;
+            return Archive.printFileIoError(.opening, archive_path, err);
         },
     };
     return open_file_handle;


### PR DESCRIPTION
Make sure all io errors returned by any library call go through zar's internal file io error handler. This is ensured by adding a build option to ensure a compile error if that isn't the case and adding it to the test suite.